### PR TITLE
Add environment variable for server URI

### DIFF
--- a/mobile-browser-based-version/.env.development
+++ b/mobile-browser-based-version/.env.development
@@ -1,0 +1,2 @@
+# When using local server on port 8080 set to http://localhost:8080/ 
+VUE_APP_SERVER_URI=https://feai-328012.ew.r.appspot.com/

--- a/mobile-browser-based-version/.env.production
+++ b/mobile-browser-based-version/.env.production
@@ -1,0 +1,1 @@
+VUE_APP_SERVER_URI=https://feai-328012.ew.r.appspot.com/

--- a/mobile-browser-based-version/src/helpers/communication_script/communication_manager.js
+++ b/mobile-browser-based-version/src/helpers/communication_script/communication_manager.js
@@ -46,7 +46,7 @@ export class CommunicationManager {
 
     // create an ID used to connect to the server
     this.peerjsId = await makeid(10);
-    const serverUrl = 'https://feai-328012.ew.r.appspot.com/'
+    const serverUrl = process.env.VUE_APP_SERVER_URI
     const url = serverUrl.concat('connect/').concat(environment.Task.trainingInformation.modelId).concat('/').concat(this.peerjsId)
     const response = await fetch(url, {
       method: 'GET', 

--- a/mobile-browser-based-version/src/helpers/communication_script/helpers.js
+++ b/mobile-browser-based-version/src/helpers/communication_script/helpers.js
@@ -102,7 +102,7 @@ export function dataReceived(recvBuffer, key) {
 export function dataReceivedBreak(modelId, epoch) {
   return new Promise(resolve => {
     (async function waitData(n) {
-      const serverUrl = 'https://feai-328012.ew.r.appspot.com/'
+      const serverUrl = process.env.VUE_APP_SERVER_URI
       const url = serverUrl.concat('get_weights/').concat(modelId).concat('/').concat(epoch)
       const response = await fetch(url, {
         method: 'GET', 

--- a/mobile-browser-based-version/src/helpers/communication_script/peer.js
+++ b/mobile-browser-based-version/src/helpers/communication_script/peer.js
@@ -68,7 +68,7 @@ export class PeerJS {
  * @param {String} receiver name of receiver peer (must be registered in PeerJS server)
  */
 export async function sendData(data, epoch, modelId) {
-  const serverUrl = 'https://feai-328012.ew.r.appspot.com/'
+  const serverUrl = process.env.VUE_APP_SERVER_URI
   const url = serverUrl.concat('send_weights/').concat(modelId).concat('/').concat(epoch)
   const response = await fetch(url, {
     method: 'POST', 


### PR DESCRIPTION
When we develop and test changes to the server, we need to use the local server instead of GCP. Right now, when we want to switch between using GCP and local server, we need to change the URL everywhere which is cumbersome and error-prone. With [environment variables](https://cli.vuejs.org/guide/mode-and-env.html#environment-variables), we can now change the URL only in one place `.env.development`. In production (Github Pages), we always use the GCP server which is controlled in the file `.env.production`